### PR TITLE
[Feature/chat consumers] 채팅 읽음처리 로직 변경, 채팅 테스트 템플릿 수정, django-redis 설정 및 사용

### DIFF
--- a/apps/chat/consumers.py
+++ b/apps/chat/consumers.py
@@ -1,11 +1,12 @@
 import base64
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 from django.core.files.base import ContentFile
 from django.http import QueryDict
+from django_redis import get_redis_connection
 
 from apps.chat.models import Alert, Chatroom, Message
 from apps.chat.serializers import MessageSerializer
@@ -13,20 +14,28 @@ from apps.chat.utils import check_entered_chatroom
 from apps.user.models import Account
 
 logger = logging.getLogger(__name__)
+redis_conn = get_redis_connection("default")
 
 
 class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.chat_group_name = ""
+        self.chatroom_id = ""
+        self.user = ""
+
     # 소켓에 연결
     async def connect(self) -> None:
         try:
             # scope로 채팅방 id 가져오기
             self.chatroom_id = self.scope["url_route"]["kwargs"]["chatroom_id"]
-            self.chat_group_name = self.get_group_name(self.chatroom_id)
+            self.chat_group_name = self.get_group_name(int(self.chatroom_id))
 
-            if not await self.check_room_exists(self.chatroom_id):
+            chatroom = await self.get_chatroom(self.chatroom_id)
+
+            if chatroom is None:
                 await self.close(code=1008, reason="해당 채팅방이 존재하지 않습니다.")
             self.user = self.scope["user"]
-            chatroom = await database_sync_to_async(Chatroom.objects.get)(id=self.chatroom_id)
             if not await database_sync_to_async(check_entered_chatroom)(chatroom, self.user):
                 await self.close(code=1008, reason="해당 채팅방에 존재하는 유저가 아닙니다.")
             await self.channel_layer.group_add(self.chat_group_name, self.channel_name)
@@ -35,12 +44,15 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore
             logger.error("예외 발생: %s", e, exc_info=True)
             await self.close(code=1011, reason=str(e))
 
-    async def receive_json(self, content: QueryDict) -> None:
+    async def receive_json(self, content: dict[str, Any], **kwargs: Any) -> None:
         """
         클라이언트로 부터 입력받은 메시지를 받고 데이터 서버에 저장,
         그룹 접속자에게 메시지를 전달
         """
         try:
+            if content.get("exit"):
+                await self.close(1000, "채팅이 종료 되었습니다")
+                await self.disconnect(1000)
             # 수신된 JSON에서 필요한 데이터를 가져옴
             message = content.get("message")
             image = content.get("image")
@@ -52,6 +64,11 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore
             if image:
                 image_data = self.decode_image(image)
                 data["image"] = image_data
+
+            # 만약 그룹에 속한 멤버가 2명이면 메시지는 무조건 읽은것으로 상태저장
+            # django-redis를 사용해서 그룹에 속한 멤버의 수를 가져옴
+            if redis_conn.zcard(f"asgi:group:{self.chat_group_name}") == 2:
+                data["status"] = False
             chat = await self.save_chat_message(**data)
 
             # 저장된 메시지를 직렬화
@@ -61,11 +78,11 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore
             await self.channel_layer.group_send(
                 self.chat_group_name,
                 {
-                    "message_id": serializer.data.get("id"),
                     "type": "chat_message",
                     "message": serializer.data.get("text"),
                     "nickname": serializer.data.get("nickname"),
                     "image_url": serializer.data.get("image"),
+                    "status": serializer.data.get("status"),
                 },
             )
         # 예외 발생 시 내용을 json으로 보내줌
@@ -78,7 +95,7 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore
 
     # 소켓 연결 해제
     async def disconnect(self, close_code: int) -> None:
-        chat_group_name = self.get_group_name(self.chatroom_id)
+        chat_group_name = self.get_group_name(int(self.chatroom_id))
         await self.channel_layer.group_discard(chat_group_name, self.channel_name)
 
     async def chat_message(self, event: QueryDict) -> None:
@@ -86,13 +103,10 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore
         그룹으로부터 수신한 메시지를 클라이언트에 전달
         """
         try:
-            message_id = event.get("message_id")
             message = event.get("message")
             nickname = event.get("nickname")
             image_url = event.get("image_url")
-
-            # 만약 메시지 sender와 수신자의 id가 다르다면 메시지 읽음처리
-            message_obj = await self.update_message_status(message_id, self.scope["user"].id)
+            status = event.get("status")
 
             await self.send_json(
                 {
@@ -100,7 +114,7 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore
                     "message": message,
                     "nickname": nickname,
                     "image_url": image_url,
-                    "status": message_obj.status,  # 읽음 처리 된 상태를 반환
+                    "status": status,
                 }
             )
         except Message.DoesNotExist as e:
@@ -124,6 +138,13 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore
         return ContentFile(base64.b64decode(imgstr), name="image." + ext)
 
     @database_sync_to_async  # type: ignore
+    def get_chatroom(self, chatroom_id: int) -> Optional[Chatroom]:
+        try:
+            return Chatroom.objects.get(id=chatroom_id)
+        except Chatroom.DoesNotExist:
+            return None
+
+    @database_sync_to_async  # type: ignore
     def get_user(self, **kwarg: Any) -> Account:
         try:
             return Account.objects.get(**kwarg)
@@ -131,13 +152,8 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore
             raise ValueError("해당 유저를 찾을 수 없습니다.")
 
     @database_sync_to_async  # type: ignore
-    def check_room_exists(self, chatroom_id: int) -> bool:
-        # 주어진 ID로 채팅방이 존재하는지 확인합니다.
-        return Chatroom.objects.filter(id=chatroom_id).exists()
-
-    @database_sync_to_async  # type: ignore
-    def create_alert_leave_chatroom(self) -> Alert:
-        return Alert.objects.create(chatroom_id=self.chatroom_id, text="상대방이 채팅에서 나갔습니다.")
+    def create_alert_leave_chatroom(self, chatroom_id: int) -> Alert:
+        return Alert.objects.create(chatroom_id=chatroom_id, text="상대방이 채팅에서 나갔습니다.")
 
     @database_sync_to_async  # type: ignore
     def save_chat_message(self, message: str, sender: Account, chatroom_id: int, **kwargs: Any) -> Message:

--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -34,6 +34,6 @@ class Message(models.Model):
 
 
 class Alert(models.Model):
-    chatroom_id = models.ForeignKey(Chatroom, on_delete=models.CASCADE)
+    chatroom = models.ForeignKey(Chatroom, on_delete=models.CASCADE)
     text = models.TextField()
     timestamp = models.DateTimeField(auto_now_add=True)

--- a/apps/chat/templates/chat_test.html
+++ b/apps/chat/templates/chat_test.html
@@ -22,7 +22,7 @@
         <div id="chat-messages"></div>
         <input type="file" id="imageInput">
         <input type="text" id="messageInput">
-        <button id="send">Send</button>
+        <button onclick="sendMessage()">Send</button>
     </div>
 
     <script>
@@ -43,7 +43,7 @@
         let socket = null; // 전역 변수로 WebSocket 선언
 
         async function getChatList(){
-            await fetch('http://localhost:8000/api/chat/', {
+            await fetch('http://127.0.0.1:8000/api/chat/', {
                 method: 'GET',
                 headers: {
                     'Authorization': `Bearer ${access}`,
@@ -59,11 +59,10 @@
                 data.forEach(room => {
                     const roomDiv = document.createElement('div');
                     roomDiv.innerHTML = `<p>${room.user_info.nickname}</p>`;
-                    roomDiv.innerHTML += `<p>${room.last_message.text}</p>`;
+                    if (room.last_message){
+                        roomDiv.innerHTML += `<p>${room.last_message.text}</p>`;
+                    }
                     roomDiv.innerHTML += `<button onclick="enterChatRoom(${room.id})">참가하기</button>`
-                    roomDiv.onclick = function() {
-                        enterChatRoom(room.id);
-                    };
                     roomContainer.appendChild(roomDiv);
                 });
             })
@@ -72,7 +71,7 @@
             });
         }
         async function getMessages(roomId) {
-            await fetch(`http://localhost:8000/api/chat/${roomId}/`, {
+            await fetch(`http://127.0.0.1:8000/api/chat/${roomId}/`, {
                 method: 'GET',
                 headers: {
                     'Authorization': `Bearer ${access}`,
@@ -88,6 +87,7 @@
                 data.messages.forEach(message => {
                     chatContainer.innerHTML += `<p>${message.nickname} : ${message.text}, ${message.status}</p>`;
                 });
+                chatContainer.scrollTop = chatContainer.scrollHeight;
             })
             .catch(error => {
                 console.error('Error fetching chat rooms:', error);
@@ -95,60 +95,64 @@
         }
         function chatSocketClose() {
             if (socket && socket.readyState === WebSocket.OPEN) {
-                    socket.close();
-                    socket = null;
+                    socket.send(JSON.stringify({
+                        'exit': true
+                    }))
                 }
             }
         function enterChatRoom(roomId) {
+
             // WebSocket 연결
             chatSocketClose();
-            if (socket === null) {
-                socket = new WebSocket(`ws://localhost:8000/ws/chat/${roomId}/`);
-                {#const socket = new WebSocket(`ws://localhost:8000/ws/chat/${roomId}/`); // 채팅방 ID를 지정해야 합니다.#}
-                getMessages(roomId)
 
-                // 메시지 수신 처리
-                socket.onmessage = function (event) {
-                    const data = JSON.parse(event.data);
-                    console.log(data)
-                    const message = data.message;
-                    const nickname = data.nickname;
-                    const imageUrl = data.image_url;
-                    const status = data.status;
-                    console.log(imageUrl, nickname, message)
-                    const imageTag = imageUrl ? `<img src="${imageUrl}" style="width: 100px; height: 100px;">` : '';
-                    const messageHtml = `<p><strong>${nickname}:</strong> ${message}</p><span style="font-size: 13px;">${status}</span>`;
-                    chatMessages.innerHTML += imageTag + messageHtml; // 이미지와 텍스트 함께 출력
-                    chatMessages.scrollTop = chatMessages.scrollHeight;
-                };
-                // 파일 선택 이벤트 핸들러
-                imageInput.addEventListener('change', function (event) {
-                    const file = event.target.files[0];
-                    if (file) {
-                        const reader = new FileReader();
-                        reader.onload = function (event) {
-                            const imageData = event.target.result;
-                            imageInput.imageData = imageData; // 이미지 데이터를 input 요소에 저장
-                        };
-                        reader.readAsDataURL(file); // 이미지 파일을 읽음
-                    }
-                });
-                // 이미지, 텍스트 전송 함수
-                const sendButton = document.getElementById("send")
-                sendButton.addEventListener('click', function () {
-                    const imageData = imageInput.imageData || ''; // 이미지 데이터 가져오기
-                    const message = messageInput.value;
-                    socket.send(JSON.stringify({
-                        'image': imageData,
-                        'message': message,
-                        'nickname': nickname.value // 본인의 닉네임을 여기에 입력하세요.
-                    }));
-                    messageInput.value = ''; // 메시지 전송 후 입력 필드 비우기
-                    imageInput.imageData = ''; // 이미지 데이터 초기화
-                })
+            socket = new WebSocket(`ws://127.0.0.1:8000/ws/chat/${roomId}/`);
+            getMessages(roomId)
+            // 메시지 수신 처리
+            socket.onmessage = function (event) {
+                const data = JSON.parse(event.data);
+                const message = data.message;
+                const nickname = data.nickname;
+                const imageUrl = data.image_url;
+                const status = data.status;
+                const imageTag = imageUrl ? `<img src="${imageUrl}" style="width: 100px; height: 100px;">` : '';
+                const messageHtml = `<p><strong>${nickname}:</strong> ${message}</p><span style="font-size: 13px;">${status}</span>`;
+                chatMessages.innerHTML += imageTag + messageHtml; // 이미지와 텍스트 함께 출력
+                chatMessages.scrollTop = chatMessages.scrollHeight;
+            };
+                socket.onclose = function (){
+                chatMessages.innerHTML = ''
+                chatMessages.innerHTML += `<p>채팅이 종료되었습니다<p>`
             }
-        }
 
+
+
+        }
+        // 파일 선택 이벤트 핸들러
+        imageInput.addEventListener('change', function (event) {
+            const file = event.target.files[0];
+            if (file) {
+                const reader = new FileReader();
+                reader.onload = function (event) {
+                    const imageData = event.target.result;
+                    imageInput.imageData = imageData; // 이미지 데이터를 input 요소에 저장
+                };
+                reader.readAsDataURL(file); // 이미지 파일을 읽음
+            }
+        });
+        {#// 이미지, 텍스트 전송 함수#}
+        {#const sendButton = document.getElementById("send")#}
+        function sendMessage () {
+            const imageData = imageInput.imageData || ''; // 이미지 데이터 가져오기
+            const message = messageInput.value;
+            console.log(message)
+            socket.send(JSON.stringify({
+                'image': imageData,
+                'message': message,
+                {#'nickname': nickname.value // 본인의 닉네임을 여기에 입력하세요.#}
+            }));
+            messageInput.value = ''; // 메시지 전송 후 입력 필드 비우기
+            imageInput.imageData = ''; // 이미지 데이터 초기화
+        }
     </script>
 </body>
 </html>

--- a/apps/chat/views.py
+++ b/apps/chat/views.py
@@ -61,7 +61,7 @@ class ChatDetailView(APIView):
                 return Response(
                     {"msg": "이미 나간 채팅방이거나 접근할 수 없는 채팅방입니다."}, status=status.HTTP_400_BAD_REQUEST
                 )
-            serializer = serializers.EnterChatroomSerializer(chatroom)
+            serializer = serializers.EnterChatroomSerializer(chatroom, context={"user": request.user})
             return Response(serializer.data, status=status.HTTP_200_OK)
         except Chatroom.DoesNotExist:
             return Response({"msg": "해당 채팅방이 존재하지 않습니다."}, status=status.HTTP_404_NOT_FOUND)

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -37,17 +37,16 @@ CHANNEL_LAYERS = {
     },
 }
 
-# CACHES = {
-#     "default": {
-#         "BACKEND": "django_redis.cache.RedisCache",
-#         "LOCATION": "redis://127.0.0.1:6379/0",
-#         "OPTIONS": {
-#             "CLIENT_CLASS": "django_redis.client.DefaultClient",
-#         },
-#     }
-# }
-
-CSRF_TRUSTED_ORIGINS = env("CSRF_TRUSTED_ORIGINS").split(",")
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://127.0.0.1:6379/0",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
+    }
+}
+CSRF_TRUSTED_ORIGINS = ["http://*", "https://*"]
 
 # djangorestframework-simplejwt 관련 설정
 SIMPLE_JWT = {


### PR DESCRIPTION
### PR Type
<!-- 제목 형식 - [브랜치명] 변경 내용 요약 -->
<!-- 해당하는 칸에 [x] 이렇게 표시하면 체크됨 -->

- [ ] FEAT: 새로운 기능 구현(Feature)
- [x] FIX: 버그 수정(Bugfix)
- [ ] STYLE: 포맷팅 변경(Code style update)
- [x] REFACTOR: 코드 리팩토링(Refactoring - no functional changes, no api changes)
- [ ] TEST: 테스트 관련(Test)
- [ ] DEPLOY: 배포 관련(Deploy)
- [ ] CONF: 빌드, 환경 설정(Build)
- [x] CHORE: 기타 작업(Other)

### Summary


### Description
<!-- 구체적인 작업 내용, 필요시 이미지 첨부 -->
- test_chat.html
  - localhost -> 127.0.0.1 로 변경
  - socket.close() 대신 socket.send()로 'exit'=true를 보내서 백엔드에서 이를 받아서 소켓을 종료처리하도록 변경

- consumers.py
  - 기존에 check_room_exists() 메서드 대신 get_chatroom() 메서드로 변경
  - get_chatroom() : 채팅방을 get으로 가져오는데 없으면 None을 반환
  - 기존에 update_message_status()를 이용해서 읽음상태 처리하는 것을 django-redis로 직접 그룹에 접속한 멤버수를 이용해서 처리함

- serializers.py 
  - 기존: 누가 보낸 메시지든 상관없이 status를 False로 벌크업데이트
  - 업데이트 : 상대가 보낸 메시지만 status를 False로 변경

- settings.py
  - CACHES 설정 주석 해제

### Discussion
<!-- 추후 논의할 점 -->
- 
- 

### Issue Number or Link
<!-- 예시: closes #issue-number -->

