### PR TITLE
[feature/chat-consumers] Alert 모델 삭제, 읽음/안읽음 기능 수정, 테스트 코드 수정

### DIFF
--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -31,16 +31,3 @@ class Message(models.Model):
 
     def __str__(self) -> str:
         return f"{self.sender} : {self.text[:30]}.."
-
-    def get_other_user(self):
-        """
-        해당 메시지를 보낸 유저가 아닌 다른 유저를 반환
-        """
-        chatroom = self.chatroom
-        sender = self.sender
-        if chatroom:
-            if sender == chatroom.borrower:
-                return chatroom.lender
-            elif sender == chatroom.lender:
-                return chatroom.borrower
-        return None

--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -32,8 +32,15 @@ class Message(models.Model):
     def __str__(self) -> str:
         return f"{self.sender} : {self.text[:30]}.."
 
-
-class Alert(models.Model):
-    chatroom = models.ForeignKey(Chatroom, on_delete=models.CASCADE)
-    text = models.TextField()
-    timestamp = models.DateTimeField(auto_now_add=True)
+    def get_other_user(self):
+        """
+        해당 메시지를 보낸 유저가 아닌 다른 유저를 반환
+        """
+        chatroom = self.chatroom
+        sender = self.sender
+        if chatroom:
+            if sender == chatroom.borrower:
+                return chatroom.lender
+            elif sender == chatroom.lender:
+                return chatroom.borrower
+        return None

--- a/apps/chat/serializers.py
+++ b/apps/chat/serializers.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 from django.db.models import Q
 from rest_framework import serializers
 
-from apps.chat.models import Alert, Chatroom, Message
+from apps.chat.models import Chatroom, Message
 from apps.product.models import ProductImage
 
 
@@ -46,7 +46,7 @@ class CreateChatroomSerializer(serializers.ModelSerializer[Chatroom]):
     class Meta:
         model = Chatroom
         fields = "__all__"
-        read_only_fields = ["lender", "borrower_status", "lender_status"]
+        read_only_fields = ["borrower", "borrower_status", "lender_status"]
 
 
 class MessageSerializer(serializers.ModelSerializer[Message]):
@@ -58,17 +58,14 @@ class MessageSerializer(serializers.ModelSerializer[Message]):
 
 
 class EnterChatroomSerializer(serializers.ModelSerializer[Chatroom]):
-    # product_image = serializers.RelatedField(source="product.images", read_only=True)
-    # product_name = serializers.CharField(source="product.name", read_only=True)
-    # product_rental_fee = serializers.CharField(source="product.rental_fee")
-    # product_condition = serializers.CharField(source="product.condition", read_only=True)
+    product_image = serializers.SerializerMethodField()  # 상품 이미지
+    product_name = serializers.CharField(source="product.name", read_only=True)
+    product_rental_fee = serializers.CharField(source="product.rental_fee", read_only=True)
+    product_condition = serializers.CharField(source="product.condition", read_only=True)
 
     class Meta:
         model = Chatroom
-        fields = [
-            "product",
-        ]
-        # fields = ["product", "product_image", "product_name", "product_rental_fee", "product_condition"]
+        fields = ["product", "product_image", "product_name", "product_rental_fee", "product_condition"]
 
     def to_representation(self, instance: Chatroom) -> Dict[str, Any]:
         data = super().to_representation(instance)
@@ -85,3 +82,10 @@ class EnterChatroomSerializer(serializers.ModelSerializer[Chatroom]):
         data["messages"] = serializer.data
 
         return data
+
+    def get_product_image(self, obj):
+        if obj.product:
+            product_images = obj.product.productimage_set.first()
+            if product_images:
+                return product_images.image.url  # 이미지의 URL을 리턴
+        return None  # 이미지가 없을 경우 None을 리턴

--- a/apps/chat/utils.py
+++ b/apps/chat/utils.py
@@ -1,6 +1,7 @@
 from typing import Union
 
 from django.contrib.auth.models import AnonymousUser
+from django_redis import get_redis_connection
 
 from apps.chat.models import Chatroom
 from apps.user.models import Account
@@ -38,5 +39,13 @@ def delete_chatroom(chatroom: Chatroom) -> bool:
     """
     if not chatroom.borrower_status or not chatroom.lender_status:
         chatroom.delete()
+        return True
+    return False
+
+
+def check_opponent_online(chat_group_name) -> bool:
+    """django-redis를 사용해서 그룹에 속한 멤버의 수를 가져옴"""
+    redis_conn = get_redis_connection("default")
+    if redis_conn.zcard(f"asgi:group:{chat_group_name}") >= 2:
         return True
     return False

--- a/apps/chat/utils.py
+++ b/apps/chat/utils.py
@@ -46,6 +46,6 @@ def delete_chatroom(chatroom: Chatroom) -> bool:
 def check_opponent_online(chat_group_name) -> bool:
     """django-redis를 사용해서 그룹에 속한 멤버의 수를 가져옴"""
     redis_conn = get_redis_connection("default")
-    if redis_conn.zcard(f"asgi:group:{chat_group_name}") >= 2:
+    if redis_conn.zcard(f"asgi:group:{chat_group_name}") == 2:
         return True
     return False

--- a/apps/chat/views.py
+++ b/apps/chat/views.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.chat import serializers
-from apps.chat.models import Alert, Chatroom, Message
+from apps.chat.models import Chatroom, Message
 from apps.chat.utils import (
     change_entered_status,
     check_entered_chatroom,
@@ -42,7 +42,7 @@ class ChatRoomView(APIView):
     def post(self, request: Request) -> Response:
         serializer = serializers.CreateChatroomSerializer(data=request.data)
         if serializer.is_valid():
-            serializer.save(lender=request.user)
+            serializer.save(borrower=request.user)
             return Response({"msg": "Successful Created Chatroom"}, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 


### PR DESCRIPTION
### PR Type
<!-- 제목 형식 - [브랜치명] 변경 내용 요약 -->
<!-- 해당하는 칸에 [x] 이렇게 표시하면 체크됨 -->

- [ ] FEAT: 새로운 기능 구현(Feature)
- [x] FIX: 버그 수정(Bugfix)
- [ ] STYLE: 포맷팅 변경(Code style update)
- [x] REFACTOR: 코드 리팩토링(Refactoring - no functional changes, no api changes)
- [x] TEST: 테스트 관련(Test)
- [ ] DEPLOY: 배포 관련(Deploy)
- [ ] CONF: 빌드, 환경 설정(Build)
- [x] CHORE: 기타 작업(Other)

### Summary


### Description
<!-- 구체적인 작업 내용, 필요시 이미지 첨부 -->
- serializers.py
  - Alert 관련 구문 전부 삭제
  - EnterChatroomSerializer의 주석 삭제 및 코드 정리
  - product_image를 get_product_image()를 사용하는 메소드필드로 변경

- tests.py
  - 두명이 동시에 입장할 경우 opponent_state를 true로 내려주는지 테스트 추가
  - product를 생성할 때 카테고리 추가
  - lender, borrower 혼동으로 서로 바꿔줌

- utils.py
  - check_opponent_online(): 상대의 온라인 유무를 파악하는 메서드

- consumers.py
  - 소켓 접속시 상대의 온라인 유무를 알려주도록 변경
  - 종료명령어 exit 삭제
  - 데이터를 따로 분리하지않고 시리얼라이저로 직렬화한 데이터를 모두 group_send함
  - alert() 핸들러함수 추가
  - 코드 간결화
 

### Discussion
<!-- 추후 논의할 점 -->
- 
- 

### Issue Number or Link
<!-- 예시: closes #issue-number -->

