### PR TITLE
[Feature/chat-redis-caching] redis를 이용한 채팅 메시지 캐싱 기능 구현, 테스트 코드 수정, 시리얼라이저 수정

### DIFF
--- a/apps/chat/consumers.py
+++ b/apps/chat/consumers.py
@@ -1,16 +1,23 @@
-import base64
 import logging
 from typing import Any, Optional
 
+from asgiref.sync import sync_to_async
 from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
-from django.core.files.base import ContentFile
 from django.http import QueryDict
+from django.utils import timezone
 from django_redis import get_redis_connection
 
-from apps.chat.models import Chatroom, Message
-from apps.chat.serializers import MessageSerializer
-from apps.chat.utils import check_entered_chatroom, check_opponent_online
+from apps.chat.models import Chatroom
+from apps.chat.utils import (
+    cashe_set_chat_message,
+    check_entered_chatroom,
+    check_opponent_online,
+    get_group_name,
+    save_redis_to_postgres,
+    save_remaining_messages_to_postgres,
+)
+from apps.notification.utils import chat_notification
 from apps.user.models import Account
 
 logger = logging.getLogger(__name__)
@@ -21,22 +28,21 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.chat_group_name = ""
-        self.chatroom_id = ""
-        self.user = ""
+        self.chatroom_id = -1
 
     # 소켓에 연결
     async def connect(self) -> None:
         try:
             # scope로 채팅방 id 가져오기
             self.chatroom_id = self.scope["url_route"]["kwargs"]["chatroom_id"]
-            self.chat_group_name = self.get_group_name(int(self.chatroom_id))
+            self.chat_group_name = get_group_name(self.chatroom_id)
 
             chatroom = await self.get_chatroom(self.chatroom_id)
 
             if chatroom is None:
                 await self.close(code=1008, reason="해당 채팅방이 존재하지 않습니다.")
-            self.user = self.scope["user"]
-            if not await database_sync_to_async(check_entered_chatroom)(chatroom, self.user):
+            user = self.scope["user"]
+            if not await database_sync_to_async(check_entered_chatroom)(chatroom, user):
                 await self.close(code=1008, reason="해당 채팅방에 존재하는 유저가 아닙니다.")
             await self.channel_layer.group_add(self.chat_group_name, self.channel_name)
             await self.accept()
@@ -67,29 +73,42 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore
         """
         try:
             # 수신된 JSON에서 필요한 데이터를 가져옴
-            message = content.get("message")
+            text = content.get("text")
             image = content.get("image")
+            sender = content.get("sender")
 
-            # 데이터 베이스에 Message로 저장할 데이터
-            data = {"message": message, "sender": self.user, "chatroom_id": self.chatroom_id}
+            # redis에 저장할 데이터
+            data = {
+                "text": text,
+                "nickname": sender,
+                "sender_id": self.scope["user"].id,
+                "chatroom_id": self.chatroom_id,
+                "status": True,
+                "timestamp": timezone.now().isoformat(),
+            }
 
-            # 수신한 데이터에서 이미지가 있으면 base64 디코딩 후 이미지필드로 저장
+            # 수신한 데이터에서 이미지가 있으면 데이터에 포함
             if image:
-                image_data = self.decode_image(image)
-                data["image"] = image_data
+                # image_data = self.decode_image(image)
+                data["image"] = image
 
             # 만약 그룹에 속한 멤버가 2명이면 메시지는 무조건 읽은것으로 상태저장
             # django-redis를 사용해서 그룹에 속한 멤버의 수를 가져옴
             if check_opponent_online(self.chat_group_name):
                 data["status"] = False
-            chat = await self.save_chat_message(**data)
 
-            # 저장된 메시지를 직렬화
-            data = MessageSerializer(chat).data
-            data["message"] = data.pop("text")
+            # redis에 메시지를 캐싱해놓음
+            cashe_set_chat_message(self.chat_group_name, data)
+            # redis에 캐싱된 메시지가 100개가 넘으면 db로 저장하고 캐시를 비움
+            if redis_conn.llen(f"{self.chat_group_name}_messages") > 100:
+                await database_sync_to_async(save_redis_to_postgres)(self.chat_group_name)
+
             data["type"] = "chat_message"
             # 수신된 메시지와 정보를 그룹에 속한 채팅 참가자들에게 보내기
             await self.channel_layer.group_send(self.chat_group_name, data)
+            # redis에 알림이 저장되고 상대가 채팅소켓에 접속중이지 않으면 읽지않은 채팅알림을 발송
+            if data["status"]:
+                await sync_to_async(chat_notification)(chatroom_id=self.chatroom_id, data=data)
         # 예외 발생 시 내용을 json으로 보내줌
         except ValueError as e:
             logger.error("예외 발생: %s", e, exc_info=True)
@@ -100,8 +119,11 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore
 
     # 소켓 연결 해제
     async def disconnect(self, close_code: int) -> None:
-        chat_group_name = self.get_group_name(int(self.chatroom_id))
-        await self.channel_layer.group_discard(chat_group_name, self.channel_name)
+        # 레디스에 남은 메시지들을 데이터베이스에 저장
+        if redis_conn.exists(f"{self.chat_group_name}_messages") and not check_opponent_online(self.chat_group_name):
+            await database_sync_to_async(save_remaining_messages_to_postgres)(self.chat_group_name)
+        # 레디스에 남은 그룹들 모두 해제
+        await self.channel_layer.group_discard(self.chat_group_name, self.channel_name)
 
     async def alert(self, event: dict[str, Any]) -> None:
         try:
@@ -120,19 +142,6 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore
             logger.error("예외 발생: %s", e, exc_info=True)
             await self.close(code=1011, reason=str(e))
 
-    @staticmethod
-    def get_group_name(chatroom_id: int) -> str:
-        # 채팅방 id를 사용하여 고유한 그룹 이름 구성
-        return f"chat_{chatroom_id}"
-
-    @staticmethod
-    def decode_image(image_data: str) -> ContentFile[Any]:
-        # Base64 문자열 디코딩
-        format, imgstr = image_data.split(";base64,")
-        ext = format.split("/")[-1]
-
-        return ContentFile(base64.b64decode(imgstr), name="image." + ext)
-
     @database_sync_to_async  # type: ignore
     def get_chatroom(self, chatroom_id: int) -> Optional[Chatroom]:
         try:
@@ -140,6 +149,6 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore
         except Chatroom.DoesNotExist:
             return None
 
-    @database_sync_to_async  # type: ignore
-    def save_chat_message(self, message: str, sender: Account, chatroom_id: int, **kwargs: Any) -> Message:
-        return Message.objects.create(chatroom_id=chatroom_id, sender=sender, text=message, **kwargs)
+    # @database_sync_to_async  # type: ignore
+    # def save_chat_message(self, message: str, sender: Account, chatroom_id: int, **kwargs: Any) -> Message:
+    #     return Message.objects.create(chatroom_id=chatroom_id, sender=sender, text=message, **kwargs)

--- a/apps/chat/tests.py
+++ b/apps/chat/tests.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 
 from channels.db import database_sync_to_async
@@ -6,12 +7,16 @@ from channels.testing import WebsocketCommunicator
 from django.db.models import Q
 from django.test import TransactionTestCase
 from django.urls import path, reverse
+from django.utils import timezone
+from django_redis import get_redis_connection
 from rest_framework import status
 from rest_framework.test import APITestCase
+from rest_framework_simplejwt.tokens import AccessToken
 
 from apps.category.models import Category
 from apps.chat.consumers import ChatConsumer
 from apps.chat.models import Chatroom, Message
+from apps.chat.utils import get_group_name, get_unread_message_count_at_redis
 from apps.product.models import Product
 from apps.user.models import Account
 
@@ -35,12 +40,14 @@ class ChatRoomTestCase(APITestCase):
             size="XL",
         )
         self.client.force_login(user=self.user)
+        self.token = AccessToken.for_user(self.user)
+        self.redis_conn = get_redis_connection("default")
 
     def test_정상적인_채팅방_만들기_요청(self) -> None:
         url = reverse("chatroom")
         data = {"lender": self.lender.id}
 
-        response = self.client.post(url, data)
+        response = self.client.post(url, data, headers={"Authorization": f"Bearer {self.token}"})
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Chatroom.objects.count(), 1)
@@ -50,18 +57,18 @@ class ChatRoomTestCase(APITestCase):
         url = reverse("chatroom")
         data = {"lender": 13241}
 
-        response = self.client.post(url, data)
+        response = self.client.post(url, data, headers={"Authorization": f"Bearer {self.token}"})
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(Chatroom.objects.count(), 0)
 
-    def test_로그인_유저의_채팅방리스트_가져오기(self) -> None:
+    def test_로그인_유저의_채팅방리스트_가져오기_마지막_메시지가_db에_있는_경우(self) -> None:
         url = reverse("chatroom")
         # 먼저 채팅방 만들기
         chatroom = Chatroom.objects.create(lender=self.lender, borrower=self.user, product=self.product)
         last_message = Message.objects.create(sender=self.user, text="test_last_message", chatroom=chatroom)
         # 채팅방 리스트 가져오기
-        response = self.client.get(url)
+        response = self.client.get(url, headers={"Authorization": f"Bearer {self.token}"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data[0].get("id"), chatroom.id)
@@ -70,6 +77,35 @@ class ChatRoomTestCase(APITestCase):
         self.assertEqual(response.data[0]["last_message"].get("nickname"), last_message.sender.nickname)
         count = Message.objects.filter(~Q(sender=self.user), status=True, chatroom=chatroom).count()
         self.assertEqual(response.data[0]["unread_chat_count"], count)
+
+    def test_로그인_유저의_채팅방리스트_가져오기_마지막_메시지가_redis에_있는_경우(self) -> None:
+        url = reverse("chatroom")
+        # given : 채팅방을 만들고 redis에 채팅메시지를 넣어둠
+        chatroom = Chatroom.objects.create(lender=self.lender, borrower=self.user, product=self.product)
+        key = f"{get_group_name(chatroom_id=chatroom.id)}_messages"
+        data = {
+            "nickname": self.lender.nickname,
+            "sender_id": self.lender.id,
+            "chatroom_id": chatroom.id,
+            "status": True,
+            "timestamp": timezone.now().isoformat(),
+            "text": f"last chat message",
+        }
+        self.redis_conn.lpush(key, json.dumps(data))
+
+        # 채팅방 리스트 가져오기
+        response = self.client.get(url, headers={"Authorization": f"Bearer {self.token}"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data[0].get("id"), chatroom.id)
+        self.assertEqual(response.data[0]["user_info"].get("nickname"), chatroom.lender.nickname)
+        self.assertEqual(response.data[0]["last_message"].get("text"), data["text"])
+        self.assertEqual(response.data[0]["last_message"].get("nickname"), data["nickname"])
+        count = Message.objects.filter(~Q(sender=self.user), status=True, chatroom=chatroom).count()
+        count += get_unread_message_count_at_redis(chatroom_id=chatroom.id, nickname=self.user.nickname)
+        self.assertEqual(response.data[0]["unread_chat_count"], count)
+
+        self.redis_conn.delete(key)
 
 
 class ChatDetailTestCase(APITestCase):
@@ -81,50 +117,107 @@ class ChatDetailTestCase(APITestCase):
             Message.objects.create(chatroom=self.chatroom, sender=self.user, text=f"test-message-{i}")
             Message.objects.create(chatroom=self.chatroom, sender=self.lender, text=f"test-message-{i}")
         self.client.force_login(user=self.user)
+        self.token = AccessToken.for_user(self.user)
+        self.redis_conn = get_redis_connection("default")
 
-    def test_채팅에_참여한_유저가_get요청을_보내는_경우(self) -> None:
+    def test_채팅에_참여한_유저가_get요청을_보낼때_db에만_데이터가_30개미만_있는_경우(self) -> None:
         url = reverse("chat-detail", kwargs={"chatroom_id": self.chatroom.id})
-        response = self.client.get(url)
+        response = self.client.get(url, headers={"Authorization": f"Bearer {self.token}"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(self.chatroom.message_set.count(), len(response.data.get("messages")))
+
+    def test_채팅에_참여한_유저가_get요청을_보낼때_redis에만_데이터가_있는_경우(self) -> None:
+        # given : redis에 채팅 메시지 40 개를 넣어둠
+        key = f"{get_group_name(chatroom_id=self.chatroom.id)}_messages"
+        data = {
+            "nickname": self.user.nickname,
+            "sender_id": self.user.id,
+            "chatroom_id": self.chatroom.id,
+            "status": True,
+            "timestamp": timezone.now().isoformat(),
+        }
+        for i in range(40):
+            data["text"] = f"test chat message - {i + 1}"
+            self.redis_conn.lpush(key, json.dumps(data))
+
+        url = reverse("chat-detail", kwargs={"chatroom_id": self.chatroom.id})
+        response = self.client.get(url, headers={"Authorization": f"Bearer {self.token}"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data.get("messages")), 30)
+        self.assertEqual(response.data["messages"][0]["text"], "test chat message - 40")
+        self.assertEqual(response.data["messages"][-1]["text"], "test chat message - 11")
+        # 테스트가 끝나면 레디스의 자원을 정리
+        self.redis_conn.delete(key)
+
+    def test_채팅메시지가_db_redis에_분산되어_있는경우(self) -> None:
+        # given : redis에 채팅 메시지 10 개, db에 40개를 넣어둠
+        key = f"{get_group_name(chatroom_id=self.chatroom.id)}_messages"
+        data = {
+            "sender_id": self.user.id,
+            "chatroom_id": self.chatroom.id,
+            "status": True,
+        }
+        for i in range(40):
+            data["text"] = f"test chat message - {i + 1}"
+            data["timestamp"] = (timezone.now().isoformat(),)
+            if i < 30:
+                Message.objects.create(**data)
+            else:
+                data["nickname"] = self.user.nickname
+                self.redis_conn.lpush(key, json.dumps(data))
+        self.assertEqual(self.redis_conn.llen(key), 10)
+        self.assertEqual(Message.objects.count(), 50)
+
+        url = reverse("chat-detail", kwargs={"chatroom_id": self.chatroom.id})
+        response = self.client.get(url, headers={"Authorization": f"Bearer {self.token}"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data.get("messages")), 30)
+        self.assertEqual(response.data["messages"][0]["text"], "test chat message - 40")
+        self.assertEqual(response.data["messages"][-1]["text"], "test chat message - 11")
+
+        # 테스트가 끝나면 레디스의 자원을 정리
+        self.redis_conn.delete(key)
 
     def test_비정상적인_유저가_get요청을_보내는_경우(self) -> None:
         invaild_user = Account.objects.create_user(email="invalid-user@example.com", password="testpassword123")
         self.client.logout()
         self.client.force_login(invaild_user)
+        invalid_token = AccessToken.for_user(invaild_user)
 
         url = reverse("chat-detail", kwargs={"chatroom_id": self.chatroom.id})
-        response = self.client.get(url)
+        response = self.client.get(url, headers={"Authorization": f"Bearer {invalid_token}"})
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data.get("msg"), "이미 나간 채팅방이거나 접근할 수 없는 채팅방입니다.")
 
     def test_유효하지않은_채팅방ID로_get요청을_보내는_경우(self) -> None:
         url = reverse("chat-detail", kwargs={"chatroom_id": 123112314})
-        response = self.client.get(url)
+        response = self.client.get(url, headers={"Authorization": f"Bearer {self.token}"})
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(response.data.get("msg"), "해당 채팅방이 존재하지 않습니다.")
 
     def test_채팅방에서_한명만_나갈때_delete요청을_보내는_경우(self) -> None:
         url = reverse("chat-detail", kwargs={"chatroom_id": self.chatroom.id})
-        response = self.client.delete(url)
+        response = self.client.delete(url, headers={"Authorization": f"Bearer {self.token}"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("msg"), "채팅방 나가기에 성공했습니다.")
 
     def test_채팅방에서_한명이_나간상태에서_delete요청을_보내는_경우(self) -> None:
         url = reverse("chat-detail", kwargs={"chatroom_id": self.chatroom.id})
-        response = self.client.delete(url)
+        response = self.client.delete(url, headers={"Authorization": f"Bearer {self.token}"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("msg"), "채팅방 나가기에 성공했습니다.")
 
         self.client.logout()
         self.client.force_login(self.lender)
-
-        response = self.client.delete(url)
+        lender_token = AccessToken.for_user(self.lender)
+        response = self.client.delete(url, headers={"Authorization": f"Bearer {lender_token}"})
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(response.data.get("msg"), "채팅방에 남은 유저가 없어 채팅방이 삭제되었습니다.")
@@ -133,16 +226,17 @@ class ChatDetailTestCase(APITestCase):
         invaild_user = Account.objects.create_user(email="invalid-user@example.com", password="testpassword123")
         self.client.logout()
         self.client.force_login(invaild_user)
+        invalid_token = AccessToken.for_user(invaild_user)
 
         url = reverse("chat-detail", kwargs={"chatroom_id": self.chatroom.id})
-        response = self.client.delete(url)
+        response = self.client.delete(url, headers={"Authorization": f"Bearer {invalid_token}"})
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data.get("msg"), "이미 나간 채팅방이거나 접근할 수 없는 채팅방입니다.")
 
     def test_유효하지않은_채팅방ID로_delete요청을_보내는_경우(self) -> None:
         url = reverse("chat-detail", kwargs={"chatroom_id": 123112314})
-        response = self.client.delete(url)
+        response = self.client.delete(url, headers={"Authorization": f"Bearer {self.token}"})
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(response.data.get("msg"), "해당 채팅방이 존재하지 않습니다.")
@@ -182,6 +276,7 @@ class ChatConsumerTest(TransactionTestCase):
                 path("ws/chat/<int:chatroom_id>/", ChatConsumer.as_asgi()),
             ]
         )
+        self.redis_conn = get_redis_connection("default")
 
     async def test_단일유저의_웹소켓_접속과_메시지전송_테스트(self) -> None:
         # 웹소켓에 접속 요청
@@ -198,30 +293,36 @@ class ChatConsumerTest(TransactionTestCase):
 
         # 채팅메시지와 유저 정보 전송하기
         data = {
-            "message": "Test message",
-            "nickname": self.user.nickname,
+            "text": "Test message",
+            "sender": self.user.nickname,
         }
         await self.communicator.send_json_to(data)
 
         # 메시지가 올바르게 받아졌는지 확인
         message = await self.communicator.receive_json_from()
-        self.assertEqual(message.get("message"), data["message"])
-        self.assertEqual(message.get("nickname"), data["nickname"])
+        self.assertEqual(message.get("text"), data["text"])
+        self.assertEqual(message.get("nickname"), data["sender"])
 
-        # 보낸 메시지가 데이터베이스에 올바르게 저장되었는지 확인
+        # 보낸 메시지가 데이터베이스에 저장되지않고 레디스에 올바르게 저장되었는지 확인
         count = await database_sync_to_async(self.chatroom.message_set.count)()
-        self.assertEqual(count, 1)
+        self.assertEqual(count, 0)
+        key = f"{get_group_name(chatroom_id=self.chatroom.id)}_messages"
 
-        # 데이터 베이스에 저장된 메시지가 유저가 보낸 메시지와 일치하는지 확인
-        message = await database_sync_to_async(self.chatroom.message_set.first)()
-        self.assertEqual(message.chatroom.id, self.chatroom.id)
-        self.assertEqual(message.text, data["message"])
-        self.assertEqual(message.sender_id, self.user.id)
-        # 메시지의 읽음상태 확인 : 유저 혼자 채팅방에 속한 상황이므로 읽어져선 안됨
-        self.assertTrue(message.status)
+        stored_message = self.redis_conn.lrange(key, -1, -1)
+        redis_message = json.loads(stored_message[0])
 
-        # 테스트가 끝났으면 소켓을 정리함
+        self.assertEqual(redis_message.get("chatroom_id"), self.chatroom.id)
+        self.assertEqual(redis_message.get("text"), data["text"])
+        self.assertEqual(redis_message.get("sender_id"), self.user.id)
+        self.assertEqual(redis_message.get("nickname"), self.user.nickname)
+        # 메시지의 읽음상태 확인 : 두 유저가 동시에 채팅 소켓에 접속한 상태 이므로 읽음상태
+        self.assertTrue(redis_message.get("status"))
+
+        # 유저가 나가면 redis의 채팅 메시지가 db에 저장되는지 확인
         await self.communicator.disconnect()
+        self.assertFalse(self.redis_conn.exists(key))
+        messages_count = await database_sync_to_async(Message.objects.count)()
+        self.assertEqual(messages_count, 1)
 
     async def test_두유저의_웹소켓_접속과_메시지전송_테스트(self) -> None:
         # 웹소켓에 접속 요청 (첫 번째 유저)
@@ -249,8 +350,8 @@ class ChatConsumerTest(TransactionTestCase):
         self.assertEqual(opponent_online_message_to_user2["opponent_state"], "online")
         # 첫번째 유저가 보낼 메시지
         data = {
-            "message": "Message from user1",
-            "nickname": self.user.nickname,
+            "text": "Message from user1",
+            "sender": self.user.nickname,
         }
 
         # 첫번째 유저가 소켓으로 메시지 보내기
@@ -258,31 +359,33 @@ class ChatConsumerTest(TransactionTestCase):
 
         # 두번째 유저가 첫번째 유저가 보낸 메시지를 수신하는지 확인
         message_from_user1_to_user2 = await communicator2.receive_json_from()
-        self.assertEqual(message_from_user1_to_user2["message"], data["message"])
-        self.assertEqual(message_from_user1_to_user2["nickname"], data["nickname"])
+        self.assertEqual(message_from_user1_to_user2["text"], data["text"])
+        self.assertEqual(message_from_user1_to_user2["nickname"], data["sender"])
 
         # 메시지를 보낸 첫번째 유저도 같은 메시지를 수신하는지 확인
         message_from_user1_to_user1 = await communicator1.receive_json_from()
-        self.assertEqual(message_from_user1_to_user1["message"], data["message"])
-        self.assertEqual(message_from_user1_to_user1["nickname"], data["nickname"])
+        self.assertEqual(message_from_user1_to_user1["text"], data["text"])
+        self.assertEqual(message_from_user1_to_user1["nickname"], data["sender"])
 
-        # 첫번째 유저가 보낸 메시지가 데이터베이스에 올바르게 저장되었는지 확인
+        # 보낸 메시지가 데이터베이스에 저장되지않고 레디스에 올바르게 저장되었는지 확인
         count = await database_sync_to_async(self.chatroom.message_set.count)()
-        self.assertEqual(count, 1)
+        self.assertEqual(count, 0)
+        key = f"{get_group_name(chatroom_id=self.chatroom.id)}_messages"
 
-        # 데이터 베이스에 저장된 메시지가 첫번째 유저가 보낸 메시지와 일치하는지 확인
-        message = await database_sync_to_async(self.chatroom.message_set.filter(sender=self.user).first)()
-        self.assertEqual(message.chatroom.id, self.chatroom.id)
-        self.assertEqual(message.text, data["message"])
-        self.assertEqual(message.sender_id, self.user.id)
+        stored_message = self.redis_conn.lrange(key, -1, -1)
+        redis_message = json.loads(stored_message[0])
 
-        # 메시지의 읽음상태 확인 : 두번째 유저가 읽었으므로 읽음상태
-        self.assertFalse(message.status)
+        self.assertEqual(redis_message.get("chatroom_id"), self.chatroom.id)
+        self.assertEqual(redis_message.get("text"), data["text"])
+        self.assertEqual(redis_message.get("sender_id"), self.user.id)
+        self.assertEqual(redis_message.get("nickname"), self.user.nickname)
+        # 메시지의 읽음상태 확인 : 두 유저가 동시에 채팅 소켓에 접속한 상태 이므로 읽음상태
+        self.assertFalse(redis_message.get("status"))
 
         # 두번째 유저가 보낼 메시지
         data = {
-            "message": "Message from user2",
-            "nickname": self.user2.nickname,
+            "text": "Message from user2",
+            "sender": self.user2.nickname,
         }
 
         # 두번째 유저가 소켓으로 메시지 보내기
@@ -290,30 +393,38 @@ class ChatConsumerTest(TransactionTestCase):
 
         # 첫번째 유저가 두번째 유저가 보낸 메시지를 수신하는지 확인
         message_from_user2_to_user1 = await communicator1.receive_json_from()
-        self.assertEqual(message_from_user2_to_user1["message"], data["message"])
-        self.assertEqual(message_from_user2_to_user1["nickname"], data["nickname"])
+        self.assertEqual(message_from_user2_to_user1["text"], data["text"])
+        self.assertEqual(message_from_user2_to_user1["nickname"], data["sender"])
 
         # 메시지를 보낸 두번째 유저도 같은 메시지를 수신하는지 확인
         message_from_user2_to_user2 = await communicator2.receive_json_from()
-        self.assertEqual(message_from_user2_to_user2["message"], data["message"])
-        self.assertEqual(message_from_user2_to_user2["nickname"], data["nickname"])
+        self.assertEqual(message_from_user2_to_user2["text"], data["text"])
+        self.assertEqual(message_from_user2_to_user2["nickname"], data["sender"])
 
-        # 두번째 유저가 보낸 메시지가 데이터베이스에 올바르게 저장되었는지 확인
+        # 보낸 메시지가 데이터베이스에 저장되지않고 레디스에 올바르게 저장되었는지 확인
         count = await database_sync_to_async(self.chatroom.message_set.count)()
-        self.assertEqual(count, 2)
+        self.assertEqual(count, 0)
+        key = f"{get_group_name(chatroom_id=self.chatroom.id)}_messages"
 
-        # 데이터 베이스에 저장된 메시지가 두번째 유저가 보낸 메시지와 일치하는지 확인
-        message = await database_sync_to_async(self.chatroom.message_set.filter(sender=self.user2).first)()
-        self.assertEqual(message.chatroom.id, self.chatroom.id)
-        self.assertEqual(message.text, data["message"])
-        self.assertEqual(message.sender_id, self.user2.id)
+        stored_message = self.redis_conn.lrange(key, 0, -1)
+        redis_message = json.loads(stored_message[0])
 
-        # 메시지의 읽음상태 확인 : 두번째 유저가 읽었으므로 읽음상태
-        self.assertFalse(message.status)
+        self.assertEqual(redis_message.get("chatroom_id"), self.chatroom.id)
+        self.assertEqual(redis_message.get("text"), data["text"])
+        self.assertEqual(redis_message.get("sender_id"), self.user2.id)
+        self.assertEqual(redis_message.get("nickname"), self.user2.nickname)
+        # 메시지의 읽음상태 확인 : 두 유저가 동시에 채팅 소켓에 접속한 상태 이므로 읽음상태
+        self.assertFalse(redis_message.get("status"))
 
-        # 테스트가 끝났으면 소켓을 정리함
+        # 유저 1명만 나가는 경우 - redis의 채팅 메시지가 그대로 있어야함
         await communicator1.disconnect()
+        stored_message = self.redis_conn.lrange(key, 0, -1)
+        self.assertEqual(len(stored_message), 2)
+        # 마지막 유저까지 나가는 경우 -> redis의 채팅메시지가 삭제되고 db에 저장되어야함
         await communicator2.disconnect()
+        self.assertFalse(self.redis_conn.exists(key))
+        messages_count = await database_sync_to_async(Message.objects.count)()
+        self.assertEqual(messages_count, 2)
 
     async def test_허용되지않은_유저가_채팅방에_접근하는경우(self) -> None:
         invalid_user = await database_sync_to_async(Account.objects.create)(

--- a/apps/chat/utils.py
+++ b/apps/chat/utils.py
@@ -1,10 +1,20 @@
-from typing import Union
+import base64
+import json
+import logging
+from typing import Any, Optional, Union
 
+import redis
 from django.contrib.auth.models import AnonymousUser
+from django.core.files.base import ContentFile
+from django.db import transaction
+from django.db.models import Q
 from django_redis import get_redis_connection
 
-from apps.chat.models import Chatroom
+from apps.chat.models import Chatroom, Message
 from apps.user.models import Account
+
+logger = logging.getLogger(__name__)
+redis_conn = get_redis_connection("default")
 
 
 def check_entered_chatroom(chatroom: Chatroom, user: Union[Account, AnonymousUser]) -> bool:
@@ -49,3 +59,200 @@ def check_opponent_online(chat_group_name: str) -> bool:
     if redis_conn.zcard(f"asgi:group:{chat_group_name}") == 2:
         return True
     return False
+
+
+def get_group_name(chatroom_id: int) -> str:
+    # 채팅방 id를 사용하여 고유한 그룹 이름 구성
+    return f"chat_{chatroom_id}"
+
+
+def decode_image(image_data: str) -> ContentFile[Any]:
+    # Base64 문자열 디코딩
+    format, imgstr = image_data.split(";base64,")
+    ext = format.split("/")[-1]
+
+    return ContentFile(base64.b64decode(imgstr), name="image." + ext)
+
+
+def cashe_set_chat_message(chat_group_name: str, data: dict[str, Any]) -> None:
+    # Redis에 메시지를 json형식으로 직렬화하여 저장
+    try:
+        key = f"{chat_group_name}_messages"
+        redis_conn.lpush(key, json.dumps(data))
+    except Exception as e:
+        raise ValueError(str(e))
+
+
+def save_redis_to_postgres(chat_group_name: str) -> None:
+    # 메시지 수가 100개를 초과하면 저장된 메시지를 역직렬화해서 불러온 뒤 DB에 저장
+    key = f"{chat_group_name}_messages"
+
+    with redis_conn.pipeline() as pipe:
+        while True:
+            try:
+                # watch로 모니터링 시작
+                pipe.watch(key)
+                if pipe.llen(key) > 100:
+                    messages = [json.loads(msg) for msg in pipe.lrange(key, 0, -1)]
+                    for msg in messages:
+                        # 메시지 데이터에 이미지가 존재하면 디코딩 후 파일로 변환해서 db의 image필드로 s3에 저장될 수 있도록함
+                        if "image" in msg:
+                            msg["image"] = decode_image(msg["image"])
+                        msg.pop("nickname", None)
+                    bulk_messages = [Message(**msg) for msg in messages]
+                    # 트랜잭션 시작
+                    with transaction.atomic():
+                        Message.objects.bulk_create(bulk_messages)
+                        # 데이터베이스에 저장되고나면 redis에 남은 메시지들을 지움
+                        pipe.delete(key)
+                break
+            except redis.WatchError as e:
+                logger.error("예외 발생: %s", e, exc_info=True)
+                continue
+            except Exception as e:
+                logger.error("예외 발생: %s", e, exc_info=True)
+                break
+
+
+def save_remaining_messages_to_postgres(chat_group_name: str) -> None:
+    # Redis에서 남은 메시지 가져와 DB에 저장
+    key = f"{chat_group_name}_messages"
+    remaining_messages = redis_conn.lrange(key, 0, -1)
+    if remaining_messages:
+        messages = [json.loads(msg) for msg in remaining_messages]
+        for msg in messages:
+            # 메시지 데이터에 이미지가 존재하면 디코딩 후 파일로 변환해서 db의 image필드로 s3에 저장될 수 있도록함
+            if msg.get("image"):
+                msg["image"] = decode_image(msg["image"])
+            msg.pop("nickname", None)
+        bulk_messages = [Message(**msg) for msg in messages]
+        Message.objects.bulk_create(bulk_messages)
+
+    # Redis 캐시 삭제
+    redis_conn.delete(key)
+
+
+def get_last_message(chatroom_id: int) -> Optional[dict[str, Any]]:
+    key = f"{get_group_name(chatroom_id)}_messages"
+    # 만약 redis에 채팅 메시지가 존재하면 레디스에서 마지막 채팅내용을 가져옴
+    if redis_conn.exists(key):
+        stored_last_message = redis_conn.lrange(key, -1, -1)
+        last_message: dict[str, Any] = json.loads(stored_last_message[0])
+
+        return last_message
+    # redis에 채팅내용이없으면 데이터베이스에서 마지막 채팅내용을 가져옴
+    messages = Message.objects.filter(chatroom_id=chatroom_id)
+    if messages:
+        from apps.chat.serializers import MessageSerializer
+
+        return MessageSerializer(messages.order_by("-timestamp").first()).data
+
+    return None
+
+
+def get_chatroom_message(chatroom_id: int) -> Any:
+    from apps.chat.serializers import MessageSerializer
+
+    key = f"{get_group_name(chatroom_id)}_messages"
+    if redis_conn.exists(key):
+        stored_message_num = redis_conn.llen(key)
+        # 레디스에 저장된 메시지가 30개가 넘으면 가장 마지막에 저장된 메시지부터 30개를 가져옴
+        if stored_message_num >= 30:
+            stored_messages = redis_conn.lrange(key, 0, 29)
+            messages = [json.loads(msg) for msg in stored_messages]
+            return messages
+
+        # 30개가 넘지않으면 레디스에 저장된 메시지들을 가져오고
+        stored_messages = redis_conn.lrange(key, 0, -1)
+        messages = [json.loads(msg) for msg in stored_messages]
+
+        # 데이터베이스에서 30 - stored_message_num을 뺀 개수만큼 가져옴
+        db_messages = Message.objects.filter(chatroom_id=chatroom_id).order_by("-timestamp")
+
+        # 디비에 저장된 메시지가 30-stored_message_num 보다 많으면 슬라이싱해서 필요한 만큼의 데이터를 가져옴
+        if db_messages.count() >= 30 - stored_message_num:
+            serialized_messages = MessageSerializer(db_messages[: 30 - stored_message_num], many=True).data
+            return messages + serialized_messages  # type: ignore
+
+        # 디비에 저장된 메시지가 30-stored_message_num 보다 적으면 db에 저장된 채팅방의 모든 메시지를 가져옴
+        serialized_messages = MessageSerializer(db_messages, many=True).data
+        return messages + serialized_messages  # type: ignore
+
+    # 레디스에 해당 채팅방 그룹 네임으로 지정된 키값이 없으면 데이터베이스에서 채팅 메시지를 가져옴
+    db_messages = Message.objects.filter(chatroom_id=chatroom_id)
+    if db_messages:
+        if db_messages.count() >= 30:
+            serialized_messages = MessageSerializer(db_messages.order_by("-timestamp")[:30], many=True).data
+            return serialized_messages
+
+        serialized_messages = MessageSerializer(db_messages, many=True).data
+        return serialized_messages
+
+    # 어디에도 데이터가 존재하지않으면 None을 반환
+    return None
+
+
+def read_messages_at_postgres(user_id: int, chatroom_id: int) -> None:
+    """
+    postgres db에 저장된 메시지들 중 읽음상태가 아닌 것들을 읽음처리
+    """
+    messages = Message.objects.filter(~Q(sender_id=user_id), chatroom_id=chatroom_id)
+    if messages:
+        # bulk_update 메서드를 사용하여 한 번에 여러 개체를 업데이트, 안읽은 메시지들을 읽음처리
+        filter_condition = Q(status=True, id__in=messages.values_list("id", flat=True))
+        Message.objects.filter(filter_condition).update(status=False)
+
+
+def read_messages_at_redis(nickname: str, chatroom_id: int) -> None:
+    """
+    redis에 저장된 메시지들 중 읽음상태가 아닌 것들을 읽음처리
+    메시지를 읽음 처리 중에 다른 메시지가 입력되면 메시지의 순서가 보장되지 않기 때문에
+    하나의 트랜잭션으로 키를 지우는것과 다시 입력하는 것을 묶음
+    """
+    key = f"{get_group_name(chatroom_id=chatroom_id)}_messages"
+    if redis_conn.exists(key):
+        with redis_conn.pipeline() as pipe:
+            while True:
+                try:
+                    # WATCH를 사용하여 키를 모니터링
+                    pipe.watch(key)
+                    # MULTI 시작
+                    pipe.multi()
+
+                    # 메시지 가져오기
+                    stored_messages = redis_conn.lrange(key, 0, -1)
+                    messages = [json.loads(msg) for msg in stored_messages]
+
+                    # 메시지 업데이트
+                    for msg in messages:
+                        if msg["status"] and msg["nickname"] != nickname:
+                            msg["status"] = False
+
+                    # 기존 키 삭제
+                    pipe.delete(key)
+                    # 업데이트된 메시지 다시 저장
+                    for msg in messages:
+                        pipe.rpush(key, json.dumps(msg))
+
+                    # 트랜잭션 실행
+                    pipe.execute()
+                    break
+                except redis.WatchError as e:
+                    logger.error("예외 발생: %s", e, exc_info=True)
+                    continue
+                except Exception as e:
+                    logger.error("예외 발생: %s", e, exc_info=True)
+                    break
+
+
+def get_unread_message_count_at_redis(chatroom_id: int, nickname: str) -> int:
+    key = f"{get_group_name(chatroom_id=chatroom_id)}_messages"
+    count = 0
+    if redis_conn.exists(key):
+        stored_messages = redis_conn.lrange(key, 0, -1)
+        messages = [json.loads(msg) for msg in stored_messages]
+        for msg in messages:
+            if msg["status"] and msg["nickname"] != nickname:
+                count += 1
+
+    return count


### PR DESCRIPTION
### PR Type
<!-- 제목 형식 - [브랜치명] 변경 내용 요약 -->
<!-- 해당하는 칸에 [x] 이렇게 표시하면 체크됨 -->

- [x] FEAT: 새로운 기능 구현(Feature)
- [ ] FIX: 버그 수정(Bugfix)
- [ ] STYLE: 포맷팅 변경(Code style update)
- [x] REFACTOR: 코드 리팩토링(Refactoring - no functional changes, no api changes)
- [x] TEST: 테스트 관련(Test)
- [ ] DEPLOY: 배포 관련(Deploy)
- [ ] CONF: 빌드, 환경 설정(Build)
- [x] CHORE: 기타 작업(Other)

### Summary


### Description
<!-- 구체적인 작업 내용, 필요시 이미지 첨부 -->
- consumers.py
  - 클라이언트로부터 받은 redis에 받은 메시지를 저장 (line: 101)
  - redis에 해당 채팅방으로 만든 키값에 100개이상의 value가 생기면 db로 저장하고 키값을 비움 (line: 102 - 104)
  - 소켓에서 나갈 시에 상대방도 소켓에 존재하지않으면 redis에 남아있던 채팅내용을 db로 저장함 (line: 122 - 124)
  - redis에 메시지가 저장되고 status가 True(안읽음) 상태이면 상대에게 새로운 메시지 알림을 보냄 (line: 109 - 111)
  - get_group_name, decode_image를 utils.py로 이동
  - save_chat_message 주석처리

- serializers.py
  - 각 채팅방의 마지막 메시지를 가져오는 get_last_message 사용
  - get_unread_chat_count 수정
    - db_unread_count + redis_unread_count를 반환하도록 변경
    - get_unread_message_count_at_redis : redis에 저장된 상대방의 안읽은 메시지의 개수를 세어줌
  
  - db와 redis에 저장된 상대방 메시지중 안읽은 메시지를 읽음처리
    - read_messages_at_redis
    - read_messages_at_postgres
  
  - 읽음처리 완료 후 전체 메시지중 최근 메시지 30개만 읽어오도록함
    - get_chatroom_message

- chat/tests.py, notification/test.py
  - 설정 변경으로 인해 모든 api 요청의 header에 토큰값을 포함하도록 변경
  - test_로그인_유저의_채팅방리스트_가져오기_마지막_메시지가_redis에_있는_경우
    - 채팅방 리스트를 가져올 때 마지막 메시지가 redis에 저장된 경우를 테스트
    - 각 채팅방 리스트를 가져올 때 안읽은 메시지 수도 가져오는지 테스트
  
  - test_채팅에_참여한_유저가_get요청을_보낼때...
    - 채팅방에 입장시 메시지 내역을 가져올 때 redis에만 메시지가 있는경우, redis + db에 분산 되어있는 경우, db에만 있는 경우를 나눠서 테스트
  
  - 모든 웹소켓 요청 테스트에서 메시지를 보냈을 때 redis에 저장되는지를 테스트하도록 변경
  
  - 웹소켓 요청에서 모든 유저가 나갔을 때 redis에 저장되어있던 메시지들이 db에 저장되는지 테스트
  
- utils.py
  - get_group_name, decode_image을 consumers.py로 부터 가져옴
  - cashe_set_chat_message : 클라이언트로 부터 받은 채팅메시지정보를 레디스에 저장함
  - save_redis_to_postgre : 메시지 수가 100개를 초과하면 저장된 메시지를 역직렬화해서 불러온 뒤 DB에 저장, 트랜잭션과 redis pipeline을 이용해서 원자성 보장
  - save_remaining_messages_to_postgres: 모든 유저가 웹소켓에서 나갔을 때 redis에 남은 메시지들을 db로 저장
  - get_last_message : 채팅방에서 가장 마지막 메시지를 redis 또는 db에서 가져옴
  - get_chatroom_message : 채팅방의 메시지 내역중 가장 최근의 30 개를 redis 또는 db에서 가져옴
  - read_messages_at_postgres : 채팅방에 해당하는 db에 저장된 메시지중 안읽은 메시지를 읽음처리
  - read_messages_at_redis : 채팅방에 해당하는 redis에 저장된 메시지중 안읽은 메시지를 읽음처리, redis pipeline의 WME를 적용해서 원자성을 보장
  - get_unread_message_count_at_redis : 채팅방에 해당하는 redis에 저장되어있는 메시지중 상대방의 메시지 중 안읽은 메시지 수를 반환

- notification/utils.py
  - 기존에 db에 채팅메시지가 저장되면 알림을 보내주던 new_chat_notification 주석처리
  - chat_notification : redis에 채팅메시지가 저장될 때 상대가 접속중이지 않음을 확인하고 새 메시지 알림을 전송

### Discussion
<!-- 추후 논의할 점 -->
- 
- 

### Issue Number or Link
<!-- 예시: closes #issue-number -->

closes #10
