### PR TITLE
[Fix/notification-chat] 알림 확인 메서드 수정, 채팅 메시지 올바르게 내려주도록 변경

### DIFF
--- a/apps/chat/tests.py
+++ b/apps/chat/tests.py
@@ -146,8 +146,8 @@ class ChatDetailTestCase(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data.get("messages")), 30)
-        self.assertEqual(response.data["messages"][0]["text"], "test chat message - 40")
-        self.assertEqual(response.data["messages"][-1]["text"], "test chat message - 11")
+        self.assertEqual(response.data["messages"][0]["text"], "test chat message - 11")
+        self.assertEqual(response.data["messages"][-1]["text"], "test chat message - 40")
         # 테스트가 끝나면 레디스의 자원을 정리
         self.redis_conn.delete(key)
 
@@ -175,8 +175,8 @@ class ChatDetailTestCase(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data.get("messages")), 30)
-        self.assertEqual(response.data["messages"][0]["text"], "test chat message - 40")
-        self.assertEqual(response.data["messages"][-1]["text"], "test chat message - 11")
+        self.assertEqual(response.data["messages"][0]["text"], "test chat message - 11")
+        self.assertEqual(response.data["messages"][-1]["text"], "test chat message - 40")
 
         # 테스트가 끝나면 레디스의 자원을 정리
         self.redis_conn.delete(key)

--- a/apps/chat/utils.py
+++ b/apps/chat/utils.py
@@ -159,34 +159,38 @@ def get_chatroom_message(chatroom_id: int) -> Any:
         # 레디스에 저장된 메시지가 30개가 넘으면 가장 마지막에 저장된 메시지부터 30개를 가져옴
         if stored_message_num >= 30:
             stored_messages = redis_conn.lrange(key, 0, 29)
-            messages = [json.loads(msg) for msg in reversed(stored_messages)]
+            messages = [json.loads(msg) for msg in stored_messages[::-1]]
             return messages
 
         # 30개가 넘지않으면 레디스에 저장된 메시지들을 가져오고
-        stored_messages = redis_conn.lrange(key, 0, -1)
-        messages = [json.loads(msg) for msg in reversed(stored_messages)]
+        stored_messages = redis_conn.lrange(key, 0, stored_message_num)
+        messages = [json.loads(msg) for msg in stored_messages[::-1]]
 
         # 데이터베이스에서 30 - stored_message_num을 뺀 개수만큼 가져옴
-        db_messages = Message.objects.filter(chatroom_id=chatroom_id).order_by("created_at")
+        db_messages = Message.objects.filter(chatroom_id=chatroom_id).order_by("-created_at")
+
+        # db에 저장된 메시지가 없으면 레디스에 캐싱된 메시지만 가져옴
+        if not db_messages.exists():
+            return messages
 
         # 디비에 저장된 메시지가 30-stored_message_num 보다 많으면 슬라이싱해서 필요한 만큼의 데이터를 가져옴
-        if db_messages.count() >= 30 - stored_message_num:
+        if len(db_messages) >= 30 - stored_message_num:
             serialized_messages = MessageSerializer(db_messages[: 30 - stored_message_num], many=True).data
-            return serialized_messages + messages  # type: ignore
+            return serialized_messages[::-1] + messages
 
         # 디비에 저장된 메시지가 30-stored_message_num 보다 적으면 db에 저장된 채팅방의 모든 메시지를 가져옴
-        serialized_messages = MessageSerializer(db_messages.order_by("created_at"), many=True).data
-        return serialized_messages + messages  # type: ignore
+        serialized_messages = MessageSerializer(db_messages, many=True).data
+        return serialized_messages[::-1] + messages
 
     # 레디스에 해당 채팅방 그룹 네임으로 지정된 키값이 없으면 데이터베이스에서 채팅 메시지를 가져옴
     db_messages = Message.objects.filter(chatroom_id=chatroom_id)
     if db_messages:
         if db_messages.count() >= 30:
-            serialized_messages = MessageSerializer(db_messages.order_by("created_at")[:30], many=True).data
-            return serialized_messages
+            serialized_messages = MessageSerializer(db_messages[:30], many=True).data
+            return serialized_messages[::-1]
 
-        serialized_messages = MessageSerializer(db_messages.order_by("created_at"), many=True).data
-        return serialized_messages
+        serialized_messages = MessageSerializer(db_messages, many=True).data
+        return serialized_messages[::-1]
 
     # 어디에도 데이터가 존재하지않으면 None을 반환
     return None

--- a/apps/notification/utils.py
+++ b/apps/notification/utils.py
@@ -119,10 +119,12 @@ def confirm_notification(command: str, notification_id: int, user_id: int) -> No
     """
     유저가 확인한 알림을 가져와서 comfirm = True 로 변경
     """
-    if command == "RentalNotificationConfirm":
-        RentalNotification.objects.filter(id=notification_id, recipient_id=user_id).update(confirm=True)
-    if command == "globalNotificationConfirm":
-        GlobalNotificationConfirm.objects.filter(notification_id=notification_id, user_id=user_id).update(confirm=True)
+    if command == "rental_notification_confirm":
+        RentalNotification.objects.filter(id=notification_id, recipient_id=user_id, confirm=False).update(confirm=True)
+    if command == "global_notification_confirm":
+        GlobalNotificationConfirm.objects.filter(
+            notification_id=notification_id, user_id=user_id, confirm=False
+        ).update(confirm=True)
 
 
 def create_rental_notification(
@@ -167,9 +169,11 @@ def get_unread_chat_notifications(user_id: int) -> list[ReturnDict[Any, Any]]:
 
 def get_unread_notifications(user_id: int) -> dict[str, Any]:
     result: dict[str, Any] = {}
-    unread_global_notification = GlobalNotificationConfirm.objects.filter(user_id=user_id, confirm=False)
+    unread_global_notification = GlobalNotification.objects.filter(
+        globalnotificationconfirm__user_id=user_id, globalnotificationconfirm__confirm=False
+    )
     if unread_global_notification:
-        result["global_notification"] = serializers.GlobalNotificationConfirmSerializer(
+        result["global_notification"] = serializers.GlobalNotificationSerializer(
             unread_global_notification, many=True
         ).data
 


### PR DESCRIPTION
- 저번 변경사항에 채팅메시지 내려줄 때 redis의 메시지는 올바른 순서로 내려주지만 postgres 의 메시지는 역순으로 내려주는 것을 수정
- 이에 따른 테스트 코드 일부 수정 -

### PR Type
<!-- 제목 형식 - [브랜치명] 변경 내용 요약 -->
<!-- 해당하는 칸에 [x] 이렇게 표시하면 체크됨 -->

- [ ] FEAT: 새로운 기능 구현(Feature)
- [ ] FIX: 버그 수정(Bugfix)
- [ ] STYLE: 포맷팅 변경(Code style update)
- [ ] REFACTOR: 코드 리팩토링(Refactoring - no functional changes, no api changes)
- [ ] TEST: 테스트 관련(Test)
- [ ] DEPLOY: 배포 관련(Deploy)
- [ ] CONF: 빌드, 환경 설정(Build)
- [ ] CHORE: 기타 작업(Other)

### Summary


### Description
<!-- 구체적인 작업 내용, 필요시 이미지 첨부 -->
- 저번 변경사항에 채팅메시지 내려줄 때 redis의 메시지는 올바른 순서로 내려주지만 postgres 의 메시지는 역순으로 내려주는 것을 수정
- 이에 따른 테스트 코드 일부 수정

### Discussion
<!-- 추후 논의할 점 -->
- 
- 

### Issue Number or Link
<!-- 예시: closes #issue-number -->

